### PR TITLE
Fix README link to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ async fn verify(
 
 ## 📚 Examples
 
-- ✅ [Validating Google ID tokens](examples/google)  
+- ✅ [Validating Google ID tokens](examples/google.rs)  
   Includes full setup for retries, JWKS caching, and validation settings.


### PR DESCRIPTION
Small fix to the README to prevent a 404 when trying to access the example

This looks like a super convenient library!